### PR TITLE
Check for Betabound activeitem beamaxe

### DIFF
--- a/pat_mmbinds.lua
+++ b/pat_mmbinds.lua
@@ -103,7 +103,7 @@ end
 
 function getMM()
   local beamaxeItem = player.essentialItem("beamaxe")
-  if not beamaxeItem or root.itemType(beamaxeItem.name) ~= "beamminingtool" then
+  if not beamaxeItem or root.itemType(beamaxeItem.name) ~= "beamminingtool" or not root.itemHasTag(beamaxeItem.name, "miningtool") then
     return
   end
   local params = beamaxeItem.parameters


### PR DESCRIPTION
Checks if the item has the `miningtool` tag when determining if an item is a beamaxe. i did not test this but it should work :3